### PR TITLE
Add labels array as an extra message field and other small improvements

### DIFF
--- a/AlertmanagerIntegration.js
+++ b/AlertmanagerIntegration.js
@@ -62,11 +62,5 @@ class Script {
                 }]
             }
         };
-
-        return {
-            error: {
-                success: false
-            }
-        };
     }
 }

--- a/AlertmanagerIntegration.js
+++ b/AlertmanagerIntegration.js
@@ -101,7 +101,7 @@ class Script {
     getLabelsField(labelsObj) {
         let labelsArr = [];
         for (const key of Object.keys(labelsObj)) {
-            if (key == "alertname" || key == "severity") {
+            if (key == "alertname") {
                 continue;
             }
             labelsArr.push("`"+key+"="+labelsObj[key]+"`");
@@ -111,9 +111,9 @@ class Script {
     getLabelsURL(labelsObj) {
         let labelsArr = [];
         for (const key of Object.keys(labelsObj)) {
-            labelsArr.push(key+"%3D"+labelsObj[key]);
+            labelsArr.push("matcher="+encodeURIComponent(key+"="+labelsObj[key]));
         }
-        return labelsArr.join("&matcher=");
+        return labelsArr.join("&");
     }
 
     getActionButtons(endVal) {

--- a/AlertmanagerIntegration.js
+++ b/AlertmanagerIntegration.js
@@ -3,10 +3,10 @@ class Script {
         request
     }) {
         console.log(request.content);
-
+  
         var alertColor = "warning";
         if (request.content.status == "resolved") {
-            alertColor = "good";
+            alertColor = "green";
         } else if (request.content.status == "firing") {
             alertColor = "danger";
         }
@@ -15,40 +15,44 @@ class Script {
         for (i = 0; i < request.content.alerts.length; i++) {
             var endVal = request.content.alerts[i];
             var elem = {
-                title: "alertname: " + endVal.labels.alertname,
-                value: "*instance:* " + endVal.labels.instance,
+                title: "Alertname",
+                value: endVal.labels.alertname,
                 short: false
             };
-
             finFields.push(elem);
 
             if (!!endVal.annotations.summary) {
                 finFields.push({
-                    title: "summary",
+                    title: "Summary",
                     value: endVal.annotations.summary
                 });
             }
 
             if (!!endVal.labels.severity) {
                 finFields.push({
-                    title: "severity",
+                    title: "Severity",
                     value: endVal.labels.severity
                 });
             }
 
             if (!!endVal.annotations.description) {
                 finFields.push({
-                    title: "description",
+                    title: "Description",
                     value: endVal.annotations.description
                 });
             }
 
             if (!!endVal.annotations.message) {
                 finFields.push({
-                    title: "message",
+                    title: "Message",
                     value: endVal.annotations.message
                 });
             }
+
+            finFields.push({
+                title: "Labels",
+                value: getLabelsField(endVal.labels)
+            });
         }
 
         return {
@@ -62,5 +66,17 @@ class Script {
                 }]
             }
         };
+    }
+
+    getLabelsField(labelsObj) {
+        let labelsArr = [];
+        for (const key of Object.keys(labelsObj)) {
+            if (key == "alertname" || key == "severity") {
+                continue;
+            }
+            labelsArr.push(key+"="+labelsObj[key]);
+        }
+
+        return labelsArr.join(", ");
     }
 }

--- a/AlertmanagerIntegration.js
+++ b/AlertmanagerIntegration.js
@@ -29,10 +29,10 @@ class Script {
                 });
             }
 
-            if (!!endVal.annotations.severity) {
+            if (!!endVal.labels.severity) {
                 finFields.push({
                     title: "severity",
-                    value: endVal.annotations.severity
+                    value: endVal.labels.severity
                 });
             }
 
@@ -40,6 +40,13 @@ class Script {
                 finFields.push({
                     title: "description",
                     value: endVal.annotations.description
+                });
+            }
+
+            if (!!endVal.annotations.message) {
+                finFields.push({
+                    title: "message",
+                    value: endVal.annotations.message
                 });
             }
         }

--- a/AlertmanagerIntegration.js
+++ b/AlertmanagerIntegration.js
@@ -1,25 +1,23 @@
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/chat-endpoints/postmessage#message-object-example
+// https://prometheus.io/docs/alerting/latest/notifications/
 class Script {
     process_incoming_request({
         request
     }) {
-        console.log(request.content);
-
-        var alertColor = "warning";
-        if (request.content.status == "resolved") {
-            alertColor = "green";
-        } else if (request.content.status == "firing") {
-            alertColor = "danger";
-        }
-
-        let finFields = [];
+        //console.log(request.content);
+        
+        var commonText = "";
+        let alerts = [];
+        if (!!request.content.groupLabels) {
+            commonText = this.getCommonText(request.content);
+        };
         for (i = 0; i < request.content.alerts.length; i++) {
+            let finFields = [];
+            // default color
+            var alertColor = "red";
             var endVal = request.content.alerts[i];
-            var elem = {
-                title: "Alertname",
-                value: endVal.labels.alertname,
-                short: false
-            };
-            finFields.push(elem);
+            var title = endVal.labels.alertname;
+
 
             if (!!endVal.annotations.summary) {
                 finFields.push({
@@ -27,13 +25,20 @@ class Script {
                     value: endVal.annotations.summary
                 });
             }
+            
 
-            if (!!endVal.labels.severity) {
-                finFields.push({
-                    title: "Severity",
-                    value: endVal.labels.severity
-                });
+            // set color 
+            if (endVal.status == "resolved") {
+                alertColor = "green";
+            } else if (!!endVal.labels.severity && endVal.labels.severity == "warning") {
+                alertColor = "warning";
+            } else if (!!endVal.labels.severity && endVal.labels.severity == "info") {
+                alertColor = "green";
+            } else if (!!endVal.labels.severity && endVal.labels.severity == "none") {
+                alertColor = "grey";
             }
+            
+
 
             if (!!endVal.annotations.description) {
                 finFields.push({
@@ -49,24 +54,47 @@ class Script {
                 });
             }
 
+            var links = [];
+            links = this.getActionButtons(endVal);
+            if (links.length > 0) {
+                finFields.push({
+                    title: "Links",
+                    value: links.join(" ")
+                });
+            }
+
             finFields.push({
                 title: "Labels",
-                value: this.getLabelsField(endVal.labels)
+                value: this.getLabelsField(endVal.labels),
+                short: false,
             });
+            
+
+            //collapse all alerts except first two:
+            var collapsed = false;
+            if (i > 1) {
+                collapsed = true;
+            }
+            alerts.push(
+                {
+                    color: alertColor,
+                    title_link: request.content.externalURL,
+                    title: endVal.status.toUpperCase()+": "+title,
+                    fields: finFields,
+                    collapsed: collapsed
+                }
+            )
         }
 
         return {
             content: {
                 username: "Prometheus Alert",
-                attachments: [{
-                    color: alertColor,
-                    title_link: request.content.externalURL,
-                    title: "Prometheus notification",
-                    fields: finFields
-                }]
+                text: commonText,
+                attachments: alerts,
             }
         };
     }
+
 
     getLabelsField(labelsObj) {
         let labelsArr = [];
@@ -74,9 +102,69 @@ class Script {
             if (key == "alertname" || key == "severity") {
                 continue;
             }
-            labelsArr.push(key+"="+labelsObj[key]);
+            labelsArr.push("`"+key+"="+labelsObj[key]+"`");
         }
-
         return labelsArr.join(", ");
+    }
+    getLabelsURL(labelsObj) {
+        let labelsArr = [];
+        for (const key of Object.keys(labelsObj)) {
+            labelsArr.push(key+"%3D"+labelsObj[key]);
+        }
+        return labelsArr.join("&matcher=");
+    }
+
+    getActionButtons(endVal) {
+        let actions = [];
+
+        if (!!endVal.annotations.silence_url && endVal.status == "firing") {
+            actions.push("[🔕Silence]("+endVal.annotations.silence_url+"&"+this.getLabelsURL(endVal.labels)+")");
+        }
+        if (!!endVal.annotations.dashboard_url) {
+            actions.push("[📈Dashboard]("+endVal.annotations.dashboard_url+")");
+        }
+        if (!!endVal.annotations.runbook_url) {
+            actions.push("[📖Runbook]("+endVal.annotations.runbook_url+")");
+        }
+        return actions;
+    }
+
+    getCommonText(content) {
+        let commonText = [];
+        let groupLabels = [];
+        let commonLabels = [];
+        let commonAnnotations = [];
+        if (!!content.groupLabels) {
+            for (const key of Object.keys(content.groupLabels)) {
+                if (key == "alertname" || key == "severity") {
+                    continue;
+                }
+                groupLabels.push("`"+key+"="+content.groupLabels[key]+"`");
+            }
+            commonText.push("Alerts are grouped by: "+groupLabels.join(", "));
+        };
+
+        if (!!content.commonLabels) {
+            for (const key of Object.keys(content.commonLabels)) {
+                if (key == "alertname" || key == "severity") {
+                    continue;
+                }
+                commonLabels.push("`"+key+"="+content.commonLabels[key]+"`");
+            }
+            commonText.push("Common labels: " + commonLabels.join(", "));
+        };
+
+        if (!!content.commonAnnotations) {
+            for (const key of Object.keys(content.commonAnnotations)) {
+                if (key == "alertname" || key == "severity") {
+                    continue;
+                }
+                commonAnnotations.push("**"+key+"**: "+content.commonAnnotations[key]+"\n");
+            }
+            commonText.push(commonAnnotations.join(", "));
+        };
+
+        return commonText.join("\n");
+
     }
 }

--- a/AlertmanagerIntegration.js
+++ b/AlertmanagerIntegration.js
@@ -51,7 +51,7 @@ class Script {
 
             finFields.push({
                 title: "Labels",
-                value: getLabelsField(endVal.labels)
+                value: this.getLabelsField(endVal.labels)
             });
         }
 

--- a/AlertmanagerIntegration.js
+++ b/AlertmanagerIntegration.js
@@ -8,9 +8,11 @@ class Script {
         
         var commonText = "";
         let alerts = [];
-        if (!!request.content.groupLabels) {
+
+        // show only commonText if there is more than 2 alerts
+        if (!!request.content.groupLabels && request.content.alerts.length > 1) {
             commonText = this.getCommonText(request.content);
-        };
+        }
         for (i = 0; i < request.content.alerts.length; i++) {
             let finFields = [];
             // default color
@@ -136,9 +138,9 @@ class Script {
         let commonAnnotations = [];
         if (!!content.groupLabels) {
             for (const key of Object.keys(content.groupLabels)) {
-                if (key == "alertname" || key == "severity") {
-                    continue;
-                }
+                // if (key == "x") {
+                //     continue;
+                // }
                 groupLabels.push("`"+key+"="+content.groupLabels[key]+"`");
             }
             commonText.push("Alerts are grouped by: "+groupLabels.join(", "));
@@ -146,9 +148,9 @@ class Script {
 
         if (!!content.commonLabels) {
             for (const key of Object.keys(content.commonLabels)) {
-                if (key == "alertname" || key == "severity") {
-                    continue;
-                }
+                // if (key == "x") {
+                //     continue;
+                // }
                 commonLabels.push("`"+key+"="+content.commonLabels[key]+"`");
             }
             commonText.push("Common labels: " + commonLabels.join(", "));
@@ -156,12 +158,12 @@ class Script {
 
         if (!!content.commonAnnotations) {
             for (const key of Object.keys(content.commonAnnotations)) {
-                if (key == "alertname" || key == "severity") {
+                if (key == "silence_url" || key == "dashboard_url" || key == "runbook_url" || key == "__dashboardUid__" || key == "__panelId__" || key == "__alertId__") {
                     continue;
                 }
-                commonAnnotations.push("**"+key+"**: "+content.commonAnnotations[key]+"\n");
+                commonAnnotations.push("**"+key+"**: "+content.commonAnnotations[key]);
             }
-            commonText.push(commonAnnotations.join(", "));
+            commonText.push(commonAnnotations.join("\n"));
         };
 
         return commonText.join("\n");

--- a/AlertmanagerIntegration.js
+++ b/AlertmanagerIntegration.js
@@ -3,7 +3,7 @@ class Script {
         request
     }) {
         console.log(request.content);
-  
+
         var alertColor = "warning";
         if (request.content.status == "resolved") {
             alertColor = "green";


### PR DESCRIPTION
To make this integration more generic:
- Show each alert as separate attachment
   - Collapse alerts starting from ndex=2
- Add possibility to render links with icons:
   - Add runbook url,  if runbook_url annotation is present
   - Add dashboard URL, if dashboard_url annotation is present
   - Add direct link to silence, if silence_url annotation is present (useful for grafana's alertmanager page, such https://<grafana_url>/alerting/silence/new?alertmanager=<alertmanagername>. labels are automatically added to the filter
   - Show commonLabels/commonAlerts (only if multiple alerts received)
- [Add labels array as an extra field:](https://github.com/pavel-kazhavets/AlertmanagerRocketChat/commit/9ea71b5c433a34546fca1339cf884e84d696bdd7)
- Capitalize titles
- Remove instance label (might be missing, will be visible in labels)
- Remove severity from fields (save space, can be seen in labels field instead)
- Add message annotation if available instead of description + summary (pretty common)
- Get severity from labels not annotations.

Also:
- [Remove unreachable return](https://github.com/pavel-kazhavets/AlertmanagerRocketChat/commit/43a77c3c4da47dcb9dba75f2356c0fd82e38beec)

Examples:
<img width="746" alt="Screenshot 2023-04-11 at 21 00 46" src="https://user-images.githubusercontent.com/14870891/231250368-8f009d3b-598e-4570-bf98-458638e62971.png">


